### PR TITLE
Change mainline version to golang 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.8
+  - 1.9.x
   - tip
   - master
 


### PR DESCRIPTION
Update mainline version of golang for travis tests from 1.8 to 1.9.